### PR TITLE
Adding submodules status when running git status

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -52,6 +52,9 @@
 	editor = vim
 	autocrlf = input
 
+[status]
+    submoduleSummary = true
+
 [color]
     pager = true
     ui = auto


### PR DESCRIPTION
It is helpful when working with submodules to see their status as well.

Here is an example of how the git status (or gst) in case there are submodules:

On branch master
Your branch is behind 'origin/master' by 3 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)

```
modified:   test/example.xib
modified:   submodules/module1 (modified content)
modified:   submodules/module2 (new commits)
```

Submodules changed but not updated:
- submodules/module2 7a6b4cc...337c732 (29):
  > Adding ' and escaping for it 
  > after qa
